### PR TITLE
Migrate to null-safety with new rules

### DIFF
--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -18,9 +18,6 @@ linter:
     - always_use_package_imports
     - annotate_overrides
     - avoid_annotating_with_dynamic
-    # The app has some casting when the inference can not work. That is why the as
-    # usage is necessary.
-    # - avoid_as
     - avoid_bool_literals_in_conditional_expressions
     - avoid_catches_without_on_clauses
     - avoid_catching_errors
@@ -36,6 +33,7 @@ linter:
     - avoid_implementing_value_types
     - avoid_init_to_null
     - avoid_js_rounded_ints
+    - avoid_multiple_declarations_per_line
     - avoid_null_checks_in_equality_operators
     - avoid_positional_boolean_parameters
     - avoid_print
@@ -64,8 +62,7 @@ linter:
     - camel_case_types
     - cancel_subscriptions
     - cascade_invocations
-    # Experimental lint rule (null-safety)
-    # - cast_nullable_to_non_nullable
+    - cast_nullable_to_non_nullable
     - close_sinks
     - comment_references
     - constant_identifier_names
@@ -74,6 +71,7 @@ linter:
     # This is an overkill of the implementation for the diagnostics.
     # We don't need it right now.
     # - diagnostic_describe_all_properties
+    - deprecated_consistency
     - directives_ordering
     - do_not_use_environment
     - empty_catches
@@ -92,6 +90,7 @@ linter:
     - leading_newlines_in_multiline_strings
     - library_names
     - library_prefixes
+    - library_private_types_in_public_api
     - lines_longer_than_80_chars
     - list_remove_unrelated_type
     - literal_only_boolean_expressions
@@ -103,8 +102,7 @@ linter:
     - no_logic_in_create_state
     - no_runtimeType_toString
     - non_constant_identifier_names
-    # Experimental lint rule (null-safety)
-    # - null_check_on_nullable_type_parameter
+    - null_check_on_nullable_type_parameter
     - null_closures
     - omit_local_variable_types
     # Team has abstract classes/interfaces that has one method
@@ -151,6 +149,7 @@ linter:
     - prefer_is_not_operator
     - prefer_iterable_whereType
     - prefer_mixin
+    - prefer_null_aware_method_calls
     - prefer_null_aware_operators
     # When mixing relative and absolute imports it's possible to create confusion where
     # the same member gets imported in two different ways, hence it can be problematic.
@@ -165,6 +164,7 @@ linter:
     # Writing a doc for the sake of writing it, does not make any sense to me.
     # - public_member_api_docs
     - recursive_getters
+    - require_trailing_commas
     - sized_box_for_whitespace
     - slash_for_doc_comments
     - sort_child_properties_last
@@ -186,11 +186,9 @@ linter:
     - unnecessary_lambdas
     - unnecessary_new
     - unnecessary_null_aware_assignments
-    # Experimental lint rule (null-safety)
-    # - unnecessary_null_checks
+    - unnecessary_null_checks
     - unnecessary_null_in_if_null_operators
-    # Experimental lint rule (null-safety)
-    # - unnecessary_nullable_for_final_variable_declarations
+    - unnecessary_nullable_for_final_variable_declarations
     - unnecessary_overrides
     - unnecessary_parenthesis
     - unnecessary_raw_strings
@@ -200,12 +198,14 @@ linter:
     - unnecessary_this
     - unrelated_type_equality_checks
     - unsafe_html
+    - use_build_context_synchronously
     - use_full_hex_values_for_flutter_colors
     - use_function_type_syntax_for_parameters
+    - use_if_null_to_convert_nulls_to_bools
     - use_is_even_rather_than_modulo
     - use_key_in_widget_constructors
-    # Experimental lint rule (null-safety)
-    # - use_late_for_private_fields_and_variables
+    - use_late_for_private_fields_and_variables
+    - use_named_constants
     - use_raw_strings
     - use_rethrow_when_possible
     - use_setters_to_change_properties

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -198,7 +198,8 @@ linter:
     - unnecessary_this
     - unrelated_type_equality_checks
     - unsafe_html
-    - use_build_context_synchronously
+#    Experimental Lint.
+#    - use_build_context_synchronously
     - use_full_hex_values_for_flutter_colors
     - use_function_type_syntax_for_parameters
     - use_if_null_to_convert_nulls_to_bools


### PR DESCRIPTION
Here are the changes made:

1. `avoid_as` has been removed from the list (deprecated).

2. `avoid_multiple_declarations_per_line` is added. It is with the **stable** flag.
```
Prevents declaring multiple variables on a single line.

**BAD:**

String? foo, bar, baz;

**GOOD:**

String? foo;
String? bar;
String? baz;

```

3. `cast_nullable_to_non_nullable` is added as a nullability lint. It is still with the **experimental** flag.
```
Prevents casting a nullable value to a non-nullable type. This hides a null check and most of the time it is not what is expected.

I would like to bring this in because this can help us to have sound null safety and prevent tricking the VM.
```

4. `deprecated_consistency` is added. It is with the **stable** flag.
```
Do apply @Deprecated() consistently:

if a class is deprecated, its constructors should also be deprecated.
if a field is deprecated, the constructor parameter pointing to it should also be deprecated.
if a constructor parameter pointing to a field is deprecated, the field should also be deprecated.
```

5. `library_private_types_in_public_api` is added. It is with the **stable** flag.
```
For the purposes of this lint, a public API is considered to be any top-level or member declaration unless the declaration is library private or contained in a declaration that's library private. The following uses of types are checked:
```

6. `null_check_on_nullable_type_parameter` is added as a nullability lint. It is still with the **experimental** flag.
```
Don't use null check on a potentially nullable type parameter.

This is experimental but I would like to bring this in because it can add some safety net to null variables. 
```

7. `prefer_null_aware_method_calls ` is added. It is with the **stable** flag.
```
Instead of checking nullability of a function/method f before calling it you can use f?.call().
```

8. `require_trailing_commas ` is added as a nullability lint. It is still with the **experimental** flag.
```
This might be one of the most useful ones for our app. It enhances readability. 

Exception: If the final parameter/argument is positional (vs named) and is either a function literal implemented using curly braces, a literal map, a literal set, or a literal array. This exception only applies if the final parameter does not fit entirely on one line.
```

9. `unnecessary_null_checks` is added as a nullability lint. It is still with the **experimental** flag.
```
Don't apply a null check when a nullable value is accepted.

This is experimental but I would like to bring this in because it can prevent some extra null checks. 
```

10. `unnecessary_nullable_for_final_variable_declarations ` is added as a nullability lint. It is still with the **experimental** flag.
```
Use a non-nullable type for a final variable initialized with a non-nullable value.

This is experimental but this helps us to have a non-nullable final variable, if it is not used, it should be using late.
```

11. `use_if_null_to_convert_nulls_to_bools ` is added. It is with the **stable** flag.
```
Use if-null operators to convert nulls to bools.
```

12. `use_late_for_private_fields_and_variables ` is added as a nullability lint. It is still with the **experimental** flag.
```
Use late for private members with non-nullable types that are always expected to be non-null. Thus it's clear that the field is not expected to be null and it avoids null checks.

I pulled this in because I believe this will close out some possible leaks that might come in with nullable types. 
```

13. `use_named_constants ` is added. It is with the **stable** flag.
```
Where possible, use already defined const values.
```